### PR TITLE
Remove US Government connector List links Fixes #82

### DIFF
--- a/whitepapers/power-plat-d365-architecture/README.md
+++ b/whitepapers/power-plat-d365-architecture/README.md
@@ -26,6 +26,13 @@ There's also a great video that overviews all of Microsoft's Sovereign Clouds,
 ## GCC Architecture
 ![GCC Overview](files/Slide2.PNG)
 
+### GCC Power Platform Connectors
+The list of GCC Power Platform connectors available can be found below.
+
+> **Note:** This link requires authentication with a valid GCC tenant account and is not publicly accessible.
+
+[GCC Power Platform Connectors List](https://gov.flow.microsoft.us/en-us/connectors/)
+
 ### Azure Commercial vs Azure for Government in GCC
 
 Today, for GCC customers, you have the option with certain Azure connectors (e.g., SQL Server) to toggle between Azure for Government or Azure Commercial subscription.  This toggle option will eventually make its way to other Azure connectors in Power Platform GCC.
@@ -43,7 +50,21 @@ A work around for the listed scenario above is to create a Azure Logic App in Az
 ## GCC High Architecture
 ![GCC High Overview](files/Slide3.PNG)
 
+### GCC High Power Platform Connectors
+The list of GCC High Power Platform connectors available can be found below.
+
+> **Note:** This link requires authentication with a valid GCC High tenant account and is not publicly accessible.
+
+[GCC High Power Platform Connectors List](https://high.flow.microsoft.us/en-us/connectors/)
+
 ## DOD Architecture
 ![DOD Overview](files/Slide4.PNG)
+
+### DOD Power Platform Connectors
+The list of DOD Power Platform connectors available can be found below.
+
+> **Note:** This link requires authentication with a valid DoD tenant account and is not publicly accessible.
+
+[DOD Power Platform Connectors List](https://flow.appsplatform.us/en-us/connectors/)
 
 

--- a/whitepapers/power-plat-d365-architecture/README.md
+++ b/whitepapers/power-plat-d365-architecture/README.md
@@ -26,11 +26,6 @@ There's also a great video that overviews all of Microsoft's Sovereign Clouds,
 ## GCC Architecture
 ![GCC Overview](files/Slide2.PNG)
 
-### GCC Power Platform Connectors
-The list of GCC Power Platform connectors available can be found below,
-
-[GCC Power Platform Connectors List](https://gov.flow.microsoft.us/en-us/connectors/)
-
 ### Azure Commercial vs Azure for Government in GCC
 
 Today, for GCC customers, you have the option with certain Azure connectors (e.g., SQL Server) to toggle between Azure for Government or Azure Commercial subscription.  This toggle option will eventually make its way to other Azure connectors in Power Platform GCC.
@@ -48,15 +43,7 @@ A work around for the listed scenario above is to create a Azure Logic App in Az
 ## GCC High Architecture
 ![GCC High Overview](files/Slide3.PNG)
 
-### GCC High Power Platform Connectors
-The list of GCC High Power Platform connectors available can be found below,
-
-[GCC High Power Platform Connectors List](https://high.flow.microsoft.us/en-us/connectors/)
-
 ## DOD Architecture
 ![DOD Overview](files/Slide4.PNG)
 
-### DOD Power Platform Connectors
-The list of DOD Power Platform connectors available can be found below,
 
-[DOD Power Platform Connectors List](https://flow.appsplatform.us/en-us/connectors/)


### PR DESCRIPTION
The PR will fix issue: https://github.com/microsoft/Federal-Business-Applications/issues/82

The US Gov connector list links in the [README](https://github.com/microsoft/Federal-Business-Applications/tree/main/whitepapers/power-plat-d365-architecture) are no longer valid. Please remove this sections since the links are not publicly available anymore.

