### PR TITLE
Add authentication notes to US Government connector list links

### DIFF
--- a/whitepapers/power-plat-d365-architecture/README.md
+++ b/whitepapers/power-plat-d365-architecture/README.md
@@ -27,7 +27,9 @@ There's also a great video that overviews all of Microsoft's Sovereign Clouds,
 ![GCC Overview](files/Slide2.PNG)
 
 ### GCC Power Platform Connectors
-The list of GCC Power Platform connectors available can be found below,
+The list of GCC Power Platform connectors available can be found below.
+
+> **Note:** This link requires authentication with a valid GCC tenant account and is not publicly accessible.
 
 [GCC Power Platform Connectors List](https://gov.flow.microsoft.us/en-us/connectors/)
 
@@ -49,7 +51,9 @@ A work around for the listed scenario above is to create a Azure Logic App in Az
 ![GCC High Overview](files/Slide3.PNG)
 
 ### GCC High Power Platform Connectors
-The list of GCC High Power Platform connectors available can be found below,
+The list of GCC High Power Platform connectors available can be found below.
+
+> **Note:** This link requires authentication with a valid GCC High tenant account and is not publicly accessible.
 
 [GCC High Power Platform Connectors List](https://high.flow.microsoft.us/en-us/connectors/)
 
@@ -57,6 +61,8 @@ The list of GCC High Power Platform connectors available can be found below,
 ![DOD Overview](files/Slide4.PNG)
 
 ### DOD Power Platform Connectors
-The list of DOD Power Platform connectors available can be found below,
+The list of DOD Power Platform connectors available can be found below.
+
+> **Note:** This link requires authentication with a valid DoD tenant account and is not publicly accessible.
 
 [DOD Power Platform Connectors List](https://flow.appsplatform.us/en-us/connectors/)


### PR DESCRIPTION
## Summary

Adds clarifying notes to the GCC, GCC High, and DoD connector list links in the Power Platform architecture README explaining that these links require authentication with a valid tenant account for the respective government cloud region.

## Context

Issue #82 and PR #83 proposed removing these links because they appear broken. However, the links are actually valid — they just require authentication with credentials for the corresponding US Government cloud tenant (GCC, GCC High, or DoD). Rather than removing useful links, this PR adds a note under each section so users understand the links are not publicly accessible by design.

Addresses #82

Fixes: #82