### PR TITLE
Add AI Recruitment Accelerator App to main README compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Below is a listing of the sample solutions available.  These sample solution fil
 | --------- | :---: | :----: | :---: |
 | [Access Data Migration to Dataverse](demos/access-migration/README.md) | :heavy_check_mark: | | |
 | [AI Builder Drivers License Canvas App](demos/ai-builder-drivers-license/README.md) | :heavy_check_mark: | :heavy_check_mark: | |
+| [AI Recruitment Accelerator App](demos/AI%20Recruitment%20Accelerator%20App/readme.md) | :heavy_check_mark: | :heavy_check_mark: | |
 | [AI Builder Form Processing + RPA](demos/ai-builder-form-processing-rpa/README.md) | :heavy_check_mark: | :heavy_check_mark: | |
 | [Azure Computer Vision Canvas App](demos/azure-computer-vision/README.md) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | [Book a Room Template App](demos/Book-Room/README.MD) | :heavy_check_mark: | :heavy_check_mark: |  |

--- a/demos/AI Recruitment Accelerator App/readme.md
+++ b/demos/AI Recruitment Accelerator App/readme.md
@@ -6,6 +6,14 @@ This Power Apps solution allows organizations to evaluate job applicants using A
 
 ![Jane Smith Application](./assets/jane_smith_application.png)
 
+## Cloud Compatibility
+
+| GCC | GCC High | DoD |
+| :---: | :----: | :---: |
+| :heavy_check_mark: | :heavy_check_mark: | |
+
+> **Note:** This solution requires AI Builder, which is not available in DoD environments.
+
 ## Getting Started
 
 Follow these steps to get the solution running:


### PR DESCRIPTION
Adds the AI Recruitment Accelerator App to the demos compatibility table in the main README (GCC ✔️, GCC High ✔️, DoD ✗ — AI Builder is not available in DoD).

Also adds a Cloud Compatibility note to the demo's own readme calling out the DoD limitation.

Closes #76