### PR TITLE
Fix broken links and typos in docs

### DIFF
--- a/demos/d365-click-to-dial-teams/files/DialFromTeams.js
+++ b/demos/d365-click-to-dial-teams/files/DialFromTeams.js
@@ -64,7 +64,7 @@ function initiatePhoneCallWindow(executionContext ){
 
         }
     }else{
-        /* This is used to accomodate the avaiable onChange event, so the call does not re-trigger if the switch is set back to No/False */
+        /* This is used to accommodate the available onChange event, so the call does not re-trigger if the switch is set back to No/False */
     }
 
 

--- a/demos/govDelivery/README.md
+++ b/demos/govDelivery/README.md
@@ -10,7 +10,7 @@ Sample Power Automate Flow below using the custom connector,
 ## Installing the Custom Connector
 To get started, you will need a govDelivery account and an API key to connect to their APIs.  Details on govDelivery's APIs can be found below,
 
-[govDelivery API Docs](https://developer.govdelivery.com/api/tms/overview/Setup/)
+[govDelivery API Docs](https://developers.govdelivery.com/)
 
 To install the sample custom connector, download the following swagger OpenAPI connection file,
 

--- a/demos/transcript-demo-power+azure/developer-guide.md
+++ b/demos/transcript-demo-power+azure/developer-guide.md
@@ -1220,7 +1220,7 @@ For more on the Azure Batch Speech to Text transcription click[https://learn.mic
 ![image](https://github.com/microsoft/Federal-Business-Applications/assets/12347531/0422b020-a414-4b64-8d25-cce87663307b)
 
 Here's breakdown of each action:
-- **Manually trigger a flow**: This child low is triggered by 01 - Power Apps - Upload to Azure Blob flow.  It has three parameters:
+- **Manually trigger a flow**: This child flow is triggered by 01 - Power Apps - Upload to Azure Blob flow.  It has three parameters:
   - **TotalSpeakers**: How many speakers should Azure Speech to Text services expect (for diarization)
   - **BlobPath**: Path of the blob uploaded in the 01 - Power Apps - Upload to Azure Blob flow
   - **FileName**: Name of the file uploaded in the 01 - Power Apps - Upload to Azure Blob flow 
@@ -1390,7 +1390,7 @@ Due to issue/limitation of the [Azure Blob Storage trigger]([url](https://learn.
 ![image](https://github.com/microsoft/Federal-Business-Applications/assets/12347531/cf3f6466-3fd5-416b-9699-df0fab9d6e9a)  
 Here's a breakdown of each action:  
 - **Manually trigger flow**: Child flow is triggered from parent flow [02 - Azure - When Audio File Created in Blob Storage - Create Transcript](#02---azure---when-audio-file-created-in-blob-storage---create-transcript) and receives a text parameter with the transcriptions path
-- **Initialize variable  varWait**: Creates a variable with these paramters
+- **Initialize variable  varWait**: Creates a variable with these parameters
   ![image](https://github.com/microsoft/Federal-Business-Applications/assets/12347531/116b2c78-df66-43a0-939d-8ec2a0f24501)
 
   - **Name**: ```varWait```
@@ -1596,13 +1596,13 @@ Here is a breakdown of each action:
     Here are the parameters passed:
     - **Method**: ```GET```
     - **URI**: ```@{first(body('Filter_array_-_contenturl_0.json'))?['links']?['contenturl']}```
-      **_Note_**: _This flow uses the ```first()``` function to avoid the need for For Each loop. IF you are submitting mutliple files at one time to transcribe, please replace with a For Each control_  
+      **_Note_**: _This flow uses the ```first()``` function to avoid the need for For Each loop. IF you are submitting multiple files at one time to transcribe, please replace with a For Each control_  
     - **Headers**:
         -  **Ocp-Apim-Subscription-Key**: ```@parameters('Speech To Text Key (demo_SpeechToTextKey)')```
   - **Response**: Sends the full transcript JSON back to the parent flow.  
     ![image](https://github.com/microsoft/Federal-Business-Applications/assets/12347531/1c7045dc-fe01-4cb7-acc5-3b852f32dacb)  
 
-    The paramters are:
+    The parameters are:
     - **Status Code**: ```200```
     - **Body**: ```@{body('HTTP_Get_Transcript')}```
     - **Response Body JSON Schema**:

--- a/demos/transcript-demo-power+azure/installation-guide.md
+++ b/demos/transcript-demo-power+azure/installation-guide.md
@@ -33,7 +33,7 @@ Which ever version you use, the steps are basically the same:
     - **Azure Speech to Text Region**: The Azure location/region used by the Azure Batch Speech to Text services
     - **Azure Speech to Text Key**: The key for the Azure Batch Speech to Text service
     - **Azure Blob Storage Source Container**: Path to the container that will receive the audio files
-       - **Azure Blob Destination SAS URL**:  The SAS URL for the container the the transcripts go into.  <br>_Note: this SAS URL must be configured for anonymous access and have write/create priviledges._
+       - **Azure Blob Destination SAS URL**:  The SAS URL for the container the transcripts go into.  <br>_Note: this SAS URL must be configured for anonymous access and have write/create privileges._
     - **SharePoint Site**: The site where the Word document template is located
     - **Web API Endpoint**: For Databverse Web API calls
     

--- a/whitepapers/copilot/files/GenAiCopilotSettings.psm1
+++ b/whitepapers/copilot/files/GenAiCopilotSettings.psm1
@@ -112,7 +112,7 @@ function Disable-CopilotSettings{
 
     $settingsXml = [xml]$parsedSettingsValue
 
-    # check for existance of the IsDVCopilotForTextDataEnabled property
+    # check for existence of the IsDVCopilotForTextDataEnabled property
     # if it does not exist, create it and set it to false
     if ($null -eq (Select-Xml -Content $parsedSettingsValue -XPath "//IsDVCopilotForTextDataEnabled").Node) {
         $newElement = $settingsXml.CreateElement("IsDVCopilotForTextDataEnabled")
@@ -124,7 +124,7 @@ function Disable-CopilotSettings{
         $settingsXml.OrgSettings.IsDVCopilotForTextDataEnabled = "false"
     }
 
-    # check for existance of the IsAiSuggestFormulaColumnEnabled property
+    # check for existence of the IsAiSuggestFormulaColumnEnabled property
     # if it does not exist, create it and set it to false
     if ($null -eq (Select-Xml -Content $parsedSettingsValue -XPath "//IsAiSuggestFormulaColumnEnabled").Node) {
         $newElement = $settingsXml.CreateElement("IsAiSuggestFormulaColumnEnabled")

--- a/whitepapers/federal-security/README.md
+++ b/whitepapers/federal-security/README.md
@@ -132,9 +132,9 @@ We recommend using Azure Application Gateway with Power Pages to support CISA TI
 > [!NOTE]  
 > When your compliance requirements allow for platform-managed security controls, the native "turnkey" CDN and WAF features are now available in GCC for Power Pages as of May 15, 2025. Lean more: [Announcing Content Delivery Network and Web Application Firewall for US Government Cloud in Power Pages - Microsoft Power Platform Blog](https://www.microsoft.com/en-us/power-platform/blog/power-pages/announcing-content-delivery-network-and-web-application-firewall-for-us-government-cloud-in-power-pages)
 
-Below are great resource on designing a general web application to use Azure Front Door / Azure Application Gateway to meet TIC 3.0 requirements,
+Below are great resource on designing a general web application to use Azure Front Door / Azure Application Gateway to meet TIC 3.0 requirements:
 
-* [TIC 3.0 Azure Web Application Architecture](https://github.com/microsoft/Federal-App-Innovation-Community/tree/main/assets/topics/infrastructure/solutions/tic3.0/Azure-Application-Gateway)
+* [TIC 3.0 Azure Web Application Architecture](https://github.com/Azure/trusted-internet-connection/tree/main/Architecture/Azure-Application-Gateway)
 * [Implement TIC 3.0 compliance (MS Learn)](https://learn.microsoft.com/en-us/azure/architecture/networking/architecture/trusted-internet-connections)
 
 You can easily swap out the web application above with a Power Pages web application.  That design would look like this,

--- a/whitepapers/power-apps-add-custom-app-teams/README.md
+++ b/whitepapers/power-apps-add-custom-app-teams/README.md
@@ -55,7 +55,7 @@ An outline icon displays in two scenarios:
   
 The icon must be 32x32 pixels. It can be white with a transparent background or transparent with a white background (no other colors are permitted). The outline icon should not have any extra padding around the symbol.
 
-<img  alt="Image of the the outline icon with dimensions indicated and exmaples of how the icon appears in Microsoft Teams" src="https://github.com/microsoft/Federal-Business-Applications/assets/12347531/3f583831-5be4-43a5-8c5d-aeaba621d9a4" width="500px">
+<img  alt="Image of the outline icon with dimensions indicated and examples of how the icon appears in Microsoft Teams" src="https://github.com/microsoft/Federal-Business-Applications/assets/12347531/3f583831-5be4-43a5-8c5d-aeaba621d9a4" width="500px">
 
 For more, see [App Icons](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/apps-package#app-icons)
 


### PR DESCRIPTION
Fixes broken links and typos found while auditing the repo.

## Broken links / punctuation
- **whitepapers/federal-security/README.md** - replaced dead TIC 3.0 link with the current [Azure/trusted-internet-connection](https://github.com/Azure/trusted-internet-connection/tree/main/Architecture/Azure-Application-Gateway) repo path, and changed the trailing comma to a colon before the list.
- **demos/govDelivery/README.md** - updated the dead `developer.govdelivery.com` API docs link to `https://developers.govdelivery.com/`.

## Typos
- **demos/d365-click-to-dial-teams/files/DialFromTeams.js** - `accomodate the avaiable` -> `accommodate the available`
- **whitepapers/copilot/files/GenAiCopilotSettings.psm1** - `existance` -> `existence` (x2)
- **whitepapers/power-apps-add-custom-app-teams/README.md** - `the the outline` -> `the outline`; `exmaples` -> `examples`
- **demos/transcript-demo-power+azure/installation-guide.md** - `the the transcripts` -> `the transcripts`; `priviledges` -> `privileges`
- **demos/transcript-demo-power+azure/developer-guide.md** - `child low` -> `child flow`; `paramters` -> `parameters` (x2); `mutliple` -> `multiple`